### PR TITLE
Moved cache cleaning command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,13 @@ RUN choco install \
     "--add Microsoft.VisualStudio.Workload.VCToolsv \
      --add Microsoft.VisualStudio.Workload.MSBuildTools \
      --includeRecommended --quiet --locale en-US" \
-    --confirm
+    --confirm \
+	&& rmdir /S /Q C:\chococache
 
 # Separate call, env needs to be refreshed
-RUN choco install python3 --confirm && refreshenv
+RUN choco install python3 --confirm \
+	&& refreshenv \
+	&& rmdir /S /Q C:\chococache
 RUN @powershell -NoProfile -ExecutionPolicy Bypass -Command "$root = ((New-Object System.Net.WebClient).DownloadString('https://bootstrap.pypa.io/get-pip.py')) | python $root"
 
 RUN pip install \
@@ -26,5 +29,3 @@ RUN pip install \
     && conan user
 
 COPY ./conan-fallback-settings.yml %USERPROFILE%/.conan/settings.yml
-
-RUN rmdir /S /Q C:\chococache


### PR DESCRIPTION
When clean command is moved into separate layer, the previous layer with install command contains the cache, so it makes no effect. 